### PR TITLE
Modify the restart script to work for dockerized hubot, instead of systemd controlled hubot

### DIFF
--- a/restart.coffee
+++ b/restart.coffee
@@ -9,4 +9,4 @@ Process = require("child_process")
 module.exports = (robot) ->
 
     robot.respond /restart/i, (res) ->
-        Process.spawn("sudo", ["systemctl", "restart", "hubot"])
+        Process.kill()


### PR DESCRIPTION
```
* modify restart script to kill process 1 (for dockerization)
```
